### PR TITLE
I get a complaint that `--master` isn't a command without this change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ rabbitmq:
 fastrouter:
   build: ./uwsgi
   command: >
+    uwsgi
     --master
     --fastrouter-subscription-server ":8000"
     --http ":80"


### PR DESCRIPTION
I feel like this must be some sort of docker for mac issue?

From the error messaging I get it seems like it's trying to run:

```
--master --faster-router-subscriptino-server ":8000" ...
```

Any thoughts?
