### PR TITLE
Fix vault to work with latest v0.5.2 image

### DIFF
--- a/vault/config.hcl
+++ b/vault/config.hcl
@@ -1,9 +1,3 @@
-# Listen on all ports (in addition to ('-dev' default listener listens on localhost only)
-listener "tcp" {
-  address = "0.0.0.0:8201"
-  tls_disable = 1
-}
-
 # Default is 30 days (specified in hours)
 # Let's use 10 years, I don't want to remember to renew these tokens.
 default_lease_ttl = "87600h"

--- a/vault/start_vault.sh
+++ b/vault/start_vault.sh
@@ -2,12 +2,12 @@
 #
 # Starupt script for development vault. Starts dev serfver with additonal listeners and creates a default token
 
-echo "HELLO!"
-vault server -dev -config /srv/config.hcl &
+vault server -dev -dev-listen-address "0.0.0.0:8201" -config /srv/config.hcl &
 
-# Wait for startup
+export VAULT_ADDR="http://127.0.0.1:8201"
 until vault status
 do
+    echo "Waiting for vault startup..."
     sleep 1
 done
 


### PR DESCRIPTION
Also, no longer need separate interface now that we can specify DEV listen interface

Requires latest vault docker image (v0.5.2+)

@MichaelButkovic 
